### PR TITLE
Set fetch-depth: 0 for actions/checkout

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -20,6 +20,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Check out
       uses: actions/checkout@v2.3.4
+      with:
+        fetch-depth: 0
     - name: Set up JDK 8
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
After #52 deployment is broken without https://github.com/actions/checkout/pull/258.
