### PR TITLE
Use Checks rather than commit statuses

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,13 +1,15 @@
 name: cd
 on:
-  status:
   workflow_dispatch:
+  check_run:
+    types:
+    - completed
 jobs:
   cd:
     runs-on: ubuntu-latest
     steps:
     - name: Verify CI status
-      uses: jglick/verify-ci-status-action@v1
+      uses: jglick/verify-ci-status-action@main
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Release Drafter
@@ -27,7 +29,7 @@ jobs:
       with:
         java-version: 1.8
     - name: Release
-      uses: jglick/jenkins-maven-cd-action@v1
+      uses: jglick/jenkins-maven-cd-action@main
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}


### PR DESCRIPTION
Trying to use https://github.com/jglick/verify-ci-status-action/issues/1.
