### PR TITLE
Use `ConsoleHandler`, not `StreamHandler` on `System.err`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/log_cli/StderrLogConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/log_cli/StderrLogConfig.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.log_cli;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.FilePath;
@@ -168,6 +169,7 @@ import org.kohsuke.stapler.StaplerRequest;
             this.targets = targets != null ? targets : Collections.emptyList();
         }
 
+        @SuppressFBWarnings(value = "LI_LAZY_INIT_UPDATE_STATIC", justification = "really meant to manage static state this way")
         @Override public Void call() {
             if (handler == null) {
                 handler = new ConsoleHandler();

--- a/src/main/java/org/jenkinsci/plugins/log_cli/StderrLogConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/log_cli/StderrLogConfig.java
@@ -43,11 +43,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
-import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import java.util.logging.StreamHandler;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
@@ -169,12 +168,8 @@ import org.kohsuke.stapler.StaplerRequest;
 
         @Override public Void call() {
             if (handler == null) {
-                handler = new StreamHandler(System.err, new SupportLogFormatter()) {
-                    @Override public synchronized void publish(LogRecord record) {
-                        super.publish(record);
-                        flush();
-                    }
-                };
+                handler = new ConsoleHandler();
+                handler.setFormatter(new SupportLogFormatter());
             }
             if (oldLevels == null) {
                 oldLevels = new HashMap<>();


### PR DESCRIPTION
We do not wish `System.err.close()` to ever be called.