### PR TITLE
Add symbol for CasC

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/log_cli/StderrLogConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/log_cli/StderrLogConfig.java
@@ -52,6 +52,7 @@ import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -60,6 +61,7 @@ import org.kohsuke.stapler.StaplerRequest;
 /**
  * Configures loggers to print to stderr.
  */
+@Symbol("stderrLog")
 @Extension public final class StderrLogConfig extends GlobalConfiguration {
 
     private static final Logger LOGGER = Logger.getLogger(StderrLogConfig.class.getName());


### PR DESCRIPTION
Example:

```yaml
unclassified:
  stderrLog:
    targets:
    - name: hudson.model.Queue
      level: FINE
```
